### PR TITLE
feat(home): crossword 추가

### DIFF
--- a/home/src/features/crosswords/components/CrosswordCard.tsx
+++ b/home/src/features/crosswords/components/CrosswordCard.tsx
@@ -54,7 +54,7 @@ export default function CrosswordCard({
             >
               <Typography
                 color="#121212"
-                fontSize={16}
+                fontSize={[16, 18, 24]}
                 fontWeight={700}
                 sx={{
                   width: 1,

--- a/home/src/features/crosswords/components/CrosswordCard.tsx
+++ b/home/src/features/crosswords/components/CrosswordCard.tsx
@@ -1,0 +1,78 @@
+import { Box, CardActionArea, Grid, Typography } from "@mui/material";
+import { CrosswordType } from "../types";
+import { monthFormatter } from "../fixtures";
+import { useRouter } from "next/router";
+export default function CrosswordCard({
+  title,
+  author,
+  date,
+  id,
+}: CrosswordType) {
+  const router = useRouter();
+  return (
+    <Grid item xs={6}>
+      <CardActionArea
+        sx={{
+          borderRadius: "20px",
+        }}
+        onClick={() => {
+          router.push(`/crossword/${id}`);
+        }}
+      >
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          bgcolor="#ffffff"
+          borderRadius="20px"
+          height="200px"
+          sx={{
+            "&:hover": {
+              cursor: "pointer",
+              backgroundColor: "rgba(0, 0, 0, 0.04)",
+              transition: "0.1s",
+            },
+          }}
+          onClick={() => {
+            router.push(`/crossword/${id}`);
+          }}
+        >
+          <Box
+            display="flex"
+            flexDirection="column"
+            justifyContent="space-around"
+            alignItems="center"
+            height={1}
+          >
+            <Box
+              display="flex"
+              flexDirection="column"
+              justifyContent="center"
+              alignItems="center"
+              px="10px"
+              textAlign="center"
+            >
+              <Typography
+                color="#121212"
+                fontSize={16}
+                fontWeight={700}
+                sx={{
+                  width: 1,
+                  wordBreak: "keep-all",
+                }}
+              >
+                {title}
+              </Typography>
+              <Typography fontSize={12} color="#6b6b6b">
+                {monthFormatter[date.month]}. {date.year}
+              </Typography>
+            </Box>
+            <Typography fontSize={12} color="#6b6b6b">
+              {author}
+            </Typography>
+          </Box>
+        </Box>
+      </CardActionArea>
+    </Grid>
+  );
+}

--- a/home/src/features/crosswords/fixtures/index.ts
+++ b/home/src/features/crosswords/fixtures/index.ts
@@ -1,0 +1,52 @@
+import { CrosswordType } from "../types";
+
+export const monthFormatter: Record<number, string> = {
+  1: "Jan",
+  2: "Feb",
+  3: "Mar",
+  4: "Apr",
+  5: "May",
+  6: "Jun",
+  7: "Jul",
+  8: "Aug",
+  9: "Sep",
+  10: "Oct",
+  11: "Nov",
+  12: "Dec",
+};
+
+export const CROSSWORDS: CrosswordType[] = [
+  {
+    id: "1",
+    title: "Trapped!",
+    author: "Mingyu An",
+    date: {
+      year: 2024,
+      month: 2,
+    },
+    crosswordSrc:
+      "https://amuselabs.com/pmm/crossword?id=b2c6f071&set=9d98b33f6ba8991256d7072c699f4da37cb5bea6aa82d61339343fb2110b7854&embed=1",
+  },
+  {
+    id: "2",
+    title: "You can't win in the same way",
+    author: "Mingyu An",
+    date: {
+      year: 2024,
+      month: 3,
+    },
+    crosswordSrc:
+      "https://amuselabs.com/pmm/crossword?id=ee7f889e&set=9d98b33f6ba8991256d7072c699f4da37cb5bea6aa82d61339343fb2110b7854&embed=1",
+  },
+  {
+    id: "3",
+    title: "Independent School",
+    author: "Mingyu An",
+    date: {
+      year: 2024,
+      month: 4,
+    },
+    crosswordSrc:
+      "https://amuselabs.com/pmm/crossword?id=cf0ce60f&set=9d98b33f6ba8991256d7072c699f4da37cb5bea6aa82d61339343fb2110b7854&embed=1",
+  },
+];

--- a/home/src/features/crosswords/fixtures/index.ts
+++ b/home/src/features/crosswords/fixtures/index.ts
@@ -15,6 +15,31 @@ export const monthFormatter: Record<number, string> = {
   12: "Dec",
 };
 
+export const MINI_CROSSWORDS: CrosswordType[] = [
+  {
+    id: "mini-1",
+    title: "Game Components",
+    author: "Mingyu An",
+    date: {
+      year: 2023,
+      month: 12,
+    },
+    crosswordSrc:
+      "https://amuselabs.com/pmm/crossword?id=e2ebae0c&set=9d98b33f6ba8991256d7072c699f4da37cb5bea6aa82d61339343fb2110b7854&embed=1",
+  },
+  {
+    id: "mini-2",
+    title: "US",
+    author: "Mingyu An",
+    date: {
+      year: 2023,
+      month: 11,
+    },
+    crosswordSrc:
+      "https://amuselabs.com/pmm/crossword?id=3a570389&set=9d98b33f6ba8991256d7072c699f4da37cb5bea6aa82d61339343fb2110b7854&embed=1",
+  },
+];
+
 export const CROSSWORDS: CrosswordType[] = [
   {
     id: "1",
@@ -44,7 +69,7 @@ export const CROSSWORDS: CrosswordType[] = [
     author: "Mingyu An",
     date: {
       year: 2024,
-      month: 4,
+      month: 3,
     },
     crosswordSrc:
       "https://amuselabs.com/pmm/crossword?id=cf0ce60f&set=9d98b33f6ba8991256d7072c699f4da37cb5bea6aa82d61339343fb2110b7854&embed=1",

--- a/home/src/features/crosswords/types/index.ts
+++ b/home/src/features/crosswords/types/index.ts
@@ -1,0 +1,10 @@
+export interface CrosswordType {
+  id: string;
+  title: string;
+  author: string;
+  date: {
+    year: number;
+    month: number;
+  };
+  crosswordSrc: string;
+}

--- a/home/src/features/home/components/DesktopPuzzleCard.tsx
+++ b/home/src/features/home/components/DesktopPuzzleCard.tsx
@@ -28,7 +28,7 @@ export default function DesktopPuzzleCard({
         sx={{
           backgroundColor: "#F2F3F6",
           borderRadius: "20px",
-          minHeight: "100px",
+          minHeight: "90px",
           alignItems: "center",
           p: 3,
         }}

--- a/home/src/pages/crossword/[...id].tsx
+++ b/home/src/pages/crossword/[...id].tsx
@@ -12,7 +12,11 @@ import { useRouter } from "next/router";
 import Image from "next/image";
 import { ArrowBack } from "@mui/icons-material";
 import Head from "next/head";
-import { CROSSWORDS, monthFormatter } from "@/features/crosswords/fixtures";
+import {
+  CROSSWORDS,
+  MINI_CROSSWORDS,
+  monthFormatter,
+} from "@/features/crosswords/fixtures";
 
 const BACKGROUND_COLOR = "#f2f3f6";
 
@@ -25,9 +29,13 @@ export default function CrosswordPage() {
     return <div>loading...</div>;
   }
 
-  const crossword = Object.values(CROSSWORDS).find(
+  const isMini = id.includes("mini");
+
+  const crossword = [...CROSSWORDS, ...MINI_CROSSWORDS].find(
     (crossword) => crossword.id === id[0]
   );
+
+  console.log(crossword, id);
 
   if (!crossword) {
     router.back();
@@ -37,7 +45,9 @@ export default function CrosswordPage() {
   return (
     <>
       <Head>
-        <title>추로스워드 : {crossword.title}</title>
+        <title>
+          추로스워드 {isMini ? "미니" : ""} : {crossword.title}
+        </title>
       </Head>
       <Box
         alignItems="center"

--- a/home/src/pages/crossword/[...id].tsx
+++ b/home/src/pages/crossword/[...id].tsx
@@ -1,0 +1,111 @@
+import { MeetingData, QuizData } from "@/features/quiz/fixtures";
+import {
+  Alert,
+  Box,
+  Button,
+  IconButton,
+  Skeleton,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useRouter } from "next/router";
+import Image from "next/image";
+import { ArrowBack } from "@mui/icons-material";
+import Head from "next/head";
+import { CROSSWORDS, monthFormatter } from "@/features/crosswords/fixtures";
+
+const BACKGROUND_COLOR = "#f2f3f6";
+
+export default function CrosswordPage() {
+  const router = useRouter();
+
+  const { id } = router.query;
+
+  if (!id) {
+    return <div>loading...</div>;
+  }
+
+  const crossword = Object.values(CROSSWORDS).find(
+    (crossword) => crossword.id === id[0]
+  );
+
+  if (!crossword) {
+    router.back();
+    return;
+  }
+
+  return (
+    <>
+      <Head>
+        <title>추로스워드 : {crossword.title}</title>
+      </Head>
+      <Box
+        alignItems="center"
+        display="flex"
+        minHeight="100dvh"
+        flexDirection="column"
+        bgcolor={BACKGROUND_COLOR}
+      >
+        <Box
+          display="flex"
+          alignItems="center"
+          height={40}
+          width="100%"
+          justifyContent="space-between"
+          position="fixed"
+          sx={{
+            backdropFilter: "blur(2px)",
+          }}
+        >
+          <IconButton
+            size="medium"
+            sx={{
+              ml: [1, 2, 4],
+              color: "#212837",
+            }}
+            onClick={() => {
+              router.back();
+            }}
+          >
+            <ArrowBack
+              sx={{
+                fontSize: 20,
+              }}
+            />
+          </IconButton>
+        </Box>
+        <Box
+          display="flex"
+          flexDirection="column"
+          width={1}
+          textAlign="left"
+          mt="40px"
+        >
+          <Box display="flex" flexDirection="column" mx={[0, 4, 6]}>
+            <Box display="flex" flexDirection="column" mx={2}>
+              <Typography fontSize={18} fontWeight={700} color="#121212">
+                {crossword.title}
+              </Typography>
+              <Box display="flex" gap={1}>
+                <Typography fontSize={12} color="#6b6b6b">
+                  {monthFormatter[crossword.date.month]}. {crossword.date.year},
+                </Typography>
+
+                <Typography fontSize={12} color="#6b6b6b">
+                  {crossword.author}
+                </Typography>
+              </Box>
+            </Box>
+            <iframe
+              height="650px"
+              width="100%"
+              allow="web-share;"
+              src={crossword.crosswordSrc}
+              aria-label="Puzzle Me Game"
+            />
+          </Box>
+        </Box>
+      </Box>
+    </>
+  );
+}

--- a/home/src/pages/crosswords/index.tsx
+++ b/home/src/pages/crosswords/index.tsx
@@ -1,0 +1,87 @@
+import GlobalHeader from "@/components/Navigation/GlobalHeader";
+import CrosswordCard from "@/features/crosswords/components/CrosswordCard";
+import { CROSSWORDS } from "@/features/crosswords/fixtures";
+import QuizCard from "@/features/quiz/components/QuizCard";
+import { MEETINGS, MeetingData, QuizData } from "@/features/quiz/fixtures";
+import {
+  ArrowBackRounded,
+  Lightbulb,
+  NavigateBefore,
+  NavigateBeforeRounded,
+  NavigateNext,
+} from "@mui/icons-material";
+import {
+  Box,
+  Card,
+  Grid,
+  Icon,
+  IconButton,
+  MenuItem,
+  Select,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import Head from "next/head";
+
+import { useRouter } from "next/router";
+
+const BACKGROUND_COLOR = "#f2f3f6";
+
+export default function Crosswords() {
+  const router = useRouter();
+
+  return (
+    <>
+      <Head>
+        <title>추로스워드 : 서울대 추리 동아리</title>
+      </Head>
+      <GlobalHeader />
+      <Box
+        minHeight="100dvh"
+        bgcolor={BACKGROUND_COLOR}
+        display="flex"
+        justifyContent="center"
+      >
+        <Box
+          height="100vh"
+          overflow="scroll"
+          px={[2, 6, 10]}
+          width="100%"
+          maxWidth={1000}
+          pb={6}
+        >
+          <Box
+            width="100%"
+            textAlign="left"
+            color="#212837"
+            mt={[3, 4, "100px"]}
+            mb={[2, 3, 4]}
+          >
+            <Box
+              display="flex"
+              justifyContent="space-between"
+              alignItems="center"
+            >
+              <IconButton onClick={() => router.push("/")}>
+                <ArrowBackRounded />
+              </IconButton>
+            </Box>
+          </Box>
+
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            mb={3}
+          >
+            <Grid container spacing={[3, 4, 6]} width="100%">
+              {CROSSWORDS.toReversed().map((crossword) => (
+                <CrosswordCard {...crossword} />
+              ))}
+            </Grid>
+          </Box>
+        </Box>
+      </Box>
+    </>
+  );
+}

--- a/home/src/pages/crosswords/index.tsx
+++ b/home/src/pages/crosswords/index.tsx
@@ -1,34 +1,18 @@
 import GlobalHeader from "@/components/Navigation/GlobalHeader";
 import CrosswordCard from "@/features/crosswords/components/CrosswordCard";
-import { CROSSWORDS } from "@/features/crosswords/fixtures";
-import QuizCard from "@/features/quiz/components/QuizCard";
-import { MEETINGS, MeetingData, QuizData } from "@/features/quiz/fixtures";
-import {
-  ArrowBackRounded,
-  Lightbulb,
-  NavigateBefore,
-  NavigateBeforeRounded,
-  NavigateNext,
-} from "@mui/icons-material";
-import {
-  Box,
-  Card,
-  Grid,
-  Icon,
-  IconButton,
-  MenuItem,
-  Select,
-  Tooltip,
-  Typography,
-} from "@mui/material";
+import { CROSSWORDS, MINI_CROSSWORDS } from "@/features/crosswords/fixtures";
+
+import { Box, Grid, Tab, Tabs } from "@mui/material";
 import Head from "next/head";
 
-import { useRouter } from "next/router";
+import { useState } from "react";
 
 const BACKGROUND_COLOR = "#f2f3f6";
 
 export default function Crosswords() {
-  const router = useRouter();
+  const [selectedVariant, setSelectedVariant] = useState<"BASIC" | "MINI">(
+    "BASIC"
+  );
 
   return (
     <>
@@ -56,18 +40,16 @@ export default function Crosswords() {
             color="#212837"
             mt={[3, 4, "100px"]}
             mb={[2, 3, 4]}
+            borderBottom={`1px solid #e0e0e0`}
           >
-            <Box
-              display="flex"
-              justifyContent="space-between"
-              alignItems="center"
+            <Tabs
+              value={selectedVariant}
+              onChange={(e, value) => setSelectedVariant(value)}
             >
-              <IconButton onClick={() => router.push("/")}>
-                <ArrowBackRounded />
-              </IconButton>
-            </Box>
+              <Tab label="BASIC" value="BASIC" />
+              <Tab label="MINI" value="MINI" />
+            </Tabs>
           </Box>
-
           <Box
             display="flex"
             justifyContent="center"
@@ -75,9 +57,13 @@ export default function Crosswords() {
             mb={3}
           >
             <Grid container spacing={[3, 4, 6]} width="100%">
-              {CROSSWORDS.toReversed().map((crossword) => (
-                <CrosswordCard {...crossword} />
-              ))}
+              {selectedVariant === "BASIC"
+                ? CROSSWORDS.map((crossword) => (
+                    <CrosswordCard {...crossword} />
+                  ))
+                : MINI_CROSSWORDS.map((crossword) => (
+                    <CrosswordCard {...crossword} />
+                  ))}
             </Grid>
           </Box>
         </Box>

--- a/home/src/pages/index.tsx
+++ b/home/src/pages/index.tsx
@@ -34,13 +34,6 @@ const WORD_PUZZLE_CONTENTS = [
     color: "#4b89da",
     url: "/crosswords",
   },
-  // {
-  //   title: "추로스워드 미니",
-  //   src: "/image/logo/crosswordmini-logo.png",
-  //   color: "#73b1f4",
-  //   url: "/crossword-mini",
-  //   disabled: true,
-  // },
 ];
 
 dayjs.extend(weekOfYear);
@@ -183,8 +176,8 @@ export default function Churrus() {
                 <DesktopPuzzleCard
                   src="/image/logo/crossword-logo.png"
                   title={`
-                    ${recentCrosswordDate.year}년 ${recentCrosswordDate.month}월 추러스워드`}
-                  subtitle="매달 새로운 십자말풀이."
+                    ${recentCrosswordDate.year}년 ${recentCrosswordDate.month}월 추로스워드`}
+                  subtitle="창의적인 십자말풀이."
                   onClick={() => router.push("/crosswords")}
                 />
               </Box>

--- a/home/src/pages/index.tsx
+++ b/home/src/pages/index.tsx
@@ -13,6 +13,7 @@ import useRecommendedQuiz from "@/features/home/hooks/useRecommendedQuiz";
 import weekOfYear from "dayjs/plugin/weekOfYear";
 import Image from "next/image";
 import DesktopPuzzleCard from "@/features/home/components/DesktopPuzzleCard";
+import { CROSSWORDS } from "@/features/crosswords/fixtures";
 
 const WORD_PUZZLE_CONTENTS = [
   {
@@ -27,13 +28,12 @@ const WORD_PUZZLE_CONTENTS = [
     color: "#bda9b0",
     url: "/connections",
   },
-  // {
-  //   title: "추로스워드",
-  //   src: "/image/logo/crossword-logo.png",
-  //   color: "#4b89da",
-  //   url: "/crossword",
-  //   disabled: true,
-  // },
+  {
+    title: "추로스워드",
+    src: "/image/logo/crossword-logo.png",
+    color: "#4b89da",
+    url: "/crosswords",
+  },
   // {
   //   title: "추로스워드 미니",
   //   src: "/image/logo/crosswordmini-logo.png",
@@ -103,6 +103,8 @@ export default function Churrus() {
   const recommendedQuiz = useRecommendedQuiz({
     recommendCount: 8,
   });
+
+  const recentCrosswordDate = CROSSWORDS[CROSSWORDS.length - 1].date;
 
   return (
     <>
@@ -177,6 +179,13 @@ export default function Churrus() {
                   title={`Week ${dayjs().week()} 추러스 커넥션`}
                   subtitle="네 단어씩 네 묶음으로."
                   onClick={() => router.push("/connections")}
+                />
+                <DesktopPuzzleCard
+                  src="/image/logo/crossword-logo.png"
+                  title={`
+                    ${recentCrosswordDate.year}년 ${recentCrosswordDate.month}월 추러스워드`}
+                  subtitle="매달 새로운 십자말풀이."
+                  onClick={() => router.push("/crosswords")}
                 />
               </Box>
             </Box>

--- a/home/src/pages/quiz/index.tsx
+++ b/home/src/pages/quiz/index.tsx
@@ -1,7 +1,13 @@
 import GlobalHeader from "@/components/Navigation/GlobalHeader";
 import QuizCard from "@/features/quiz/components/QuizCard";
 import { MEETINGS, MeetingData, QuizData } from "@/features/quiz/fixtures";
-import { Lightbulb, NavigateBefore, NavigateNext } from "@mui/icons-material";
+import {
+  Lightbulb,
+  NavigateBefore,
+  NavigateBeforeRounded,
+  NavigateNext,
+  NavigateNextRounded,
+} from "@mui/icons-material";
 import {
   Box,
   Grid,
@@ -118,6 +124,9 @@ export default function Quiz() {
               minWidth="300px"
             >
               <IconButton
+                sx={{
+                  backgroundColor: "white",
+                }}
                 disabled={
                   MEETINGS.indexOf(selectedMeeting) === MEETINGS.length - 1
                 }
@@ -127,7 +136,11 @@ export default function Quiz() {
                   router.push(`/quiz?meeting=${MEETINGS[index + 1]}`);
                 }}
               >
-                <NavigateBefore />
+                <NavigateBeforeRounded
+                  sx={{
+                    fontSize: "2rem",
+                  }}
+                />
               </IconButton>
               <Box
                 minHeight="58px"
@@ -159,6 +172,9 @@ export default function Quiz() {
                 </Select>
               </Box>
               <IconButton
+                sx={{
+                  backgroundColor: "white",
+                }}
                 disabled={MEETINGS.indexOf(selectedMeeting) === 0}
                 onClick={() => {
                   const index = MEETINGS.indexOf(selectedMeeting);
@@ -166,7 +182,11 @@ export default function Quiz() {
                   router.push(`/quiz?meeting=${MEETINGS[index - 1]}`);
                 }}
               >
-                <NavigateNext />
+                <NavigateNextRounded
+                  sx={{
+                    fontSize: "2rem",
+                  }}
+                />
               </IconButton>
             </Box>
           </Box>


### PR DESCRIPTION

<img width="582" alt="image" src="https://github.com/mgahn0706/churrus/assets/13569506/dc799840-423a-4a15-b78b-1fe023fc4644">
<img width="593" alt="image" src="https://github.com/mgahn0706/churrus/assets/13569506/7ec51de7-ed26-4e04-b974-e0eb35b752e1">

- 크로스워드 퍼즐을 추가합니다.
- puzzleMe에 업로드 후, iframe src값을 지정하여 가져오도록합니다.