### PR TITLE
Fix fruit market gameplay flow

### DIFF
--- a/home/src/features/fruit-market/components/DealerRoomPhase.tsx
+++ b/home/src/features/fruit-market/components/DealerRoomPhase.tsx
@@ -8,6 +8,7 @@ import {
   Select,
   Typography,
 } from "@mui/material";
+import { ArrowBackRounded } from "@mui/icons-material";
 import {
   formatFruitMarketMoney as money,
   FRUIT_META,
@@ -38,11 +39,13 @@ export default function DealerRoomPhase({ game }: DealerRoomPhaseProps) {
     setReplacementFruit,
     currentPlayerFruits,
     marketFruits,
+    replacementFruitOptions,
     bidFruits,
     bidComplete,
     selectSpecial,
     setPlayerBid,
     submitBids,
+    leaveDealerRoomWithoutSubmitting,
   } = game;
 
   if (!currentPlayer) return null;
@@ -82,7 +85,12 @@ export default function DealerRoomPhase({ game }: DealerRoomPhaseProps) {
                 }
               >
                 <MenuItem value="secret">비밀</MenuItem>
-                <MenuItem value="replace">교체</MenuItem>
+                <MenuItem
+                  value="replace"
+                  disabled={replacementFruitOptions.length === 0}
+                >
+                  교체
+                </MenuItem>
               </Select>
               <Select
                 value={targetFruit}
@@ -106,13 +114,11 @@ export default function DealerRoomPhase({ game }: DealerRoomPhaseProps) {
                     setReplacementFruit(event.target.value as Fruit)
                   }
                 >
-                  {marketFruits
-                    .filter((fruit) => fruit !== targetFruit)
-                    .map((fruit) => (
-                      <MenuItem key={fruit} value={fruit}>
-                        {FRUIT_META[fruit].emoji} {fruit}로 교체
-                      </MenuItem>
-                    ))}
+                  {replacementFruitOptions.map((fruit) => (
+                    <MenuItem key={fruit} value={fruit}>
+                      {FRUIT_META[fruit].emoji} {fruit}로 교체
+                    </MenuItem>
+                  ))}
                 </Select>
               )}
             </Box>
@@ -152,17 +158,31 @@ export default function DealerRoomPhase({ game }: DealerRoomPhaseProps) {
             </Paper>
           ))}
         </Box>
-        <Button
-          variant="contained"
-          size="large"
-          disabled={!bidComplete}
-          onClick={submitBids}
-          sx={{ mt: 3, bgcolor: "#30241C" }}
-        >
-          {bidPlayerIds.length === players.length - 1
-            ? "라운드 마감"
-            : "희망가 제출"}
-        </Button>
+        <Box display="flex" flexWrap="wrap" gap={1.25} mt={3}>
+          <Button
+            variant="outlined"
+            size="large"
+            onClick={leaveDealerRoomWithoutSubmitting}
+            startIcon={<ArrowBackRounded />}
+            sx={{
+              borderColor: "#30241C",
+              color: "#30241C",
+            }}
+          >
+            돌아가기
+          </Button>
+          <Button
+            variant="contained"
+            size="large"
+            disabled={!bidComplete}
+            onClick={submitBids}
+            sx={{ bgcolor: "#30241C" }}
+          >
+            {bidPlayerIds.length === players.length - 1
+              ? "라운드 마감"
+              : "희망가 제출"}
+          </Button>
+        </Box>
       </Box>
     </FruitMarketStage>
   );

--- a/home/src/features/fruit-market/components/FinalResultPhase.tsx
+++ b/home/src/features/fruit-market/components/FinalResultPhase.tsx
@@ -1,20 +1,64 @@
-import { Box, Chip, Paper, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Paper,
+  Typography,
+} from "@mui/material";
+import { CloseRounded, HistoryRounded } from "@mui/icons-material";
 import {
   formatFruitMarketMoney as money,
   FRUIT_META,
+  FRUITS,
 } from "@/features/fruit-market/constants";
 import { FruitMarketGame } from "@/features/fruit-market/hooks/useFruitMarketGame";
+import { FruitMarketSpecial } from "@/features/fruit-market/types";
 import FruitMarketStage from "./FruitMarketStage";
+import { useState } from "react";
 
 interface FinalResultPhaseProps {
   game: FruitMarketGame;
 }
 
 export default function FinalResultPhase({ game }: FinalResultPhaseProps) {
-  const { players } = game;
+  const { players, gameLogs } = game;
+  const [logOpen, setLogOpen] = useState(false);
+
+  const specialLabel = (
+    special: FruitMarketSpecial,
+    targetFruit?: string,
+    replacementFruit?: string,
+  ) => {
+    if (special === "secret" && targetFruit) {
+      return `비밀: ${targetFruit}`;
+    }
+    if (special === "replace" && targetFruit && replacementFruit) {
+      return `교체: ${targetFruit} -> ${replacementFruit}`;
+    }
+    return "없음";
+  };
 
   return (
     <FruitMarketStage eyebrow="MARKET CLOSED" title="최종 수입">
+      <Box display="flex" justifyContent="flex-end" mb={1.5}>
+        <Button
+          variant="outlined"
+          startIcon={<HistoryRounded />}
+          onClick={() => setLogOpen(true)}
+          sx={{
+            borderColor: "#30241C",
+            color: "#30241C",
+            fontWeight: 900,
+          }}
+        >
+          로그
+        </Button>
+      </Box>
       <Box display="grid" gap={1}>
         {[...players]
           .sort((a, b) => b.income - a.income)
@@ -60,6 +104,98 @@ export default function FinalResultPhase({ game }: FinalResultPhaseProps) {
             </Paper>
           ))}
       </Box>
+      <Dialog
+        open={logOpen}
+        onClose={() => setLogOpen(false)}
+        fullWidth
+        maxWidth="md"
+      >
+        <DialogTitle
+          display="flex"
+          alignItems="center"
+          justifyContent="space-between"
+          fontWeight={900}
+        >
+          진행 로그
+          <IconButton onClick={() => setLogOpen(false)} aria-label="닫기">
+            <CloseRounded />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent>
+          <Box display="grid" gap={2} pb={1}>
+            {gameLogs.map((roundLog) => (
+              <Box key={roundLog.round}>
+                <Typography fontWeight={950} color="#30241C" mb={1}>
+                  {roundLog.round}라운드
+                </Typography>
+                <Box
+                  display="grid"
+                  gridTemplateColumns="repeat(auto-fit, minmax(180px, 1fr))"
+                  gap={1}
+                >
+                  {roundLog.players.map((playerLog) => (
+                    <Paper
+                      key={`${roundLog.round}-${playerLog.playerId}`}
+                      variant="outlined"
+                      sx={{
+                        p: 1.5,
+                        borderRadius: 2,
+                        minWidth: 0,
+                      }}
+                    >
+                      <Typography
+                        fontWeight={900}
+                        mb={0.75}
+                        noWrap
+                        title={playerLog.playerName}
+                      >
+                        {playerLog.playerName}
+                      </Typography>
+                      <Box display="flex" flexWrap="wrap" gap={0.75} mb={1}>
+                        {FRUITS.filter(
+                          (fruit) => playerLog.bids[fruit] !== undefined,
+                        ).map((fruit) => (
+                          <Chip
+                            key={fruit}
+                            label={`${FRUIT_META[fruit].emoji} ${fruit} ${money(
+                              playerLog.bids[fruit] ?? 0,
+                            )}`}
+                            sx={{
+                              bgcolor: FRUIT_META[fruit].soft,
+                              color: FRUIT_META[fruit].color,
+                              fontWeight: 800,
+                              maxWidth: "100%",
+                              "& .MuiChip-label": {
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                              },
+                            }}
+                          />
+                        ))}
+                      </Box>
+                      <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        sx={{ wordBreak: "keep-all" }}
+                      >
+                        특수 행동:{" "}
+                        {specialLabel(
+                          playerLog.special,
+                          playerLog.targetFruit,
+                          playerLog.replacementFruit,
+                        )}
+                      </Typography>
+                    </Paper>
+                  ))}
+                </Box>
+                {roundLog.round !== gameLogs[gameLogs.length - 1]?.round && (
+                  <Divider sx={{ mt: 2 }} />
+                )}
+              </Box>
+            ))}
+          </Box>
+        </DialogContent>
+      </Dialog>
     </FruitMarketStage>
   );
 }

--- a/home/src/features/fruit-market/components/SetupPhase.tsx
+++ b/home/src/features/fruit-market/components/SetupPhase.tsx
@@ -20,6 +20,7 @@ export default function SetupPhase({ game }: SetupPhaseProps) {
     participants,
     requiredCount,
     totalCount,
+    maxFruitCount,
     setupReady,
     changeCount,
     startGame,
@@ -135,7 +136,14 @@ export default function SetupPhase({ game }: SetupPhaseProps) {
           </Box>
           {!setupReady && (
             <Typography variant="body2" color="text.secondary" mt={1.5}>
-              참가자 2명 이상, 과일 2종 이상, 총 {requiredCount}개가 필요합니다.
+              참가자 2명 이상, 과일 2종 이상, 총 {requiredCount}개가
+              필요하며 같은 과일은 최대 {participants.length}개까지 가능합니다.
+            </Typography>
+          )}
+          {participants.length > 0 && maxFruitCount > participants.length && (
+            <Typography variant="body2" color="error.main" mt={0.75}>
+              한 사람이 같은 과일을 두 개 받지 않으려면 특정 과일 수량이
+              참가자 수를 넘을 수 없습니다.
             </Typography>
           )}
         </Box>

--- a/home/src/features/fruit-market/hooks/useFruitMarketGame.ts
+++ b/home/src/features/fruit-market/hooks/useFruitMarketGame.ts
@@ -15,6 +15,45 @@ const createEmptyFruitCounts = () =>
     number
   >;
 
+const shuffle = <T,>(items: T[]) => {
+  const nextItems = [...items];
+  for (let index = nextItems.length - 1; index > 0; index -= 1) {
+    const other = Math.floor(Math.random() * (index + 1));
+    [nextItems[index], nextItems[other]] = [nextItems[other], nextItems[index]];
+  }
+  return nextItems;
+};
+
+const createFruitPairs = (counts: Record<Fruit, number>) => {
+  const remaining = shuffle(
+    FRUITS.map((fruit) => ({
+      fruit,
+      count: counts[fruit],
+    })).filter(({ count }) => count > 0),
+  );
+  const pairs: [Fruit, Fruit][] = [];
+
+  while (remaining.length > 0) {
+    remaining.sort((a, b) => b.count - a.count);
+    const first = remaining[0];
+    const second = remaining[1];
+
+    if (!second) break;
+
+    pairs.push([first.fruit, second.fruit]);
+    first.count -= 1;
+    second.count -= 1;
+
+    for (let index = remaining.length - 1; index >= 0; index -= 1) {
+      if (remaining[index].count === 0) {
+        remaining.splice(index, 1);
+      }
+    }
+  }
+
+  return shuffle(pairs);
+};
+
 export function useFruitMarketGame() {
   const [phase, setPhase] = useState<FruitMarketPhase>("setup");
   const [participantNames, setParticipantNames] = useState("");
@@ -41,11 +80,17 @@ export function useFruitMarketGame() {
     (sum, count) => sum + count,
     0,
   );
+  const maxFruitCount = Math.max(0, ...Object.values(counts));
   const marketFruits = FRUITS.filter((fruit) => counts[fruit] > 0);
   const currentPlayer = players.find((player) => player.id === activePlayerId);
   const currentPlayerFruits = useMemo(
     () => (currentPlayer ? uniqueFruits(currentPlayer.fruits) : []),
     [currentPlayer],
+  );
+  const replacementFruitOptions = useMemo(
+    () =>
+      marketFruits.filter((fruit) => !currentPlayerFruits.includes(fruit)),
+    [currentPlayerFruits, marketFruits],
   );
   const bidFruits = useMemo(() => {
     if (special !== "replace" || !currentPlayer) return currentPlayerFruits;
@@ -62,9 +107,13 @@ export function useFruitMarketGame() {
   const setupReady =
     participants.length >= 2 &&
     totalCount === requiredCount &&
-    marketFruits.length >= 2;
+    marketFruits.length >= 2 &&
+    maxFruitCount <= participants.length;
+  const replacementReady =
+    special !== "replace" || replacementFruitOptions.includes(replacementFruit);
   const bidComplete = currentPlayer
-    ? bidFruits.every((fruit) => bids[currentPlayer.id]?.[fruit])
+    ? replacementReady &&
+      bidFruits.every((fruit) => bids[currentPlayer.id]?.[fruit])
     : false;
 
   const changeCount = (fruit: Fruit, amount: number) => {
@@ -75,18 +124,14 @@ export function useFruitMarketGame() {
   };
 
   const startGame = () => {
-    const deck = FRUITS.flatMap((fruit) =>
-      Array.from({ length: counts[fruit] }, () => fruit),
-    );
-    for (let index = deck.length - 1; index > 0; index -= 1) {
-      const other = Math.floor(Math.random() * (index + 1));
-      [deck[index], deck[other]] = [deck[other], deck[index]];
-    }
+    if (!setupReady) return;
+
+    const fruitPairs = createFruitPairs(counts);
     setPlayers(
       participants.map((name, id) => ({
         id,
         name,
-        fruits: [deck[id * 2], deck[id * 2 + 1]],
+        fruits: fruitPairs[id],
         income: 0,
         usedSpecial: false,
       })),
@@ -109,6 +154,19 @@ export function useFruitMarketGame() {
   const selectPlayer = (playerId: number) => {
     setActivePlayerId(playerId);
     setRoomOpen(false);
+    setSpecial("none");
+  };
+
+  const leaveDealerRoomWithoutSubmitting = () => {
+    if (activePlayerId !== null) {
+      setBids((previous) => {
+        const nextBids = { ...previous };
+        delete nextBids[activePlayerId];
+        return nextBids;
+      });
+    }
+    setSpecial("none");
+    closePrivateRoom();
   };
 
   const selectSpecial = (nextSpecial: FruitMarketSpecial) => {
@@ -117,10 +175,7 @@ export function useFruitMarketGame() {
       nextSpecial === "replace" ? currentPlayerFruits[0] : marketFruits[0];
     setTargetFruit(nextTargetFruit);
     if (nextSpecial === "replace") {
-      setReplacementFruit(
-        marketFruits.find((fruit) => fruit !== nextTargetFruit) ??
-          nextTargetFruit,
-      );
+      setReplacementFruit(replacementFruitOptions[0] ?? nextTargetFruit);
     }
   };
 
@@ -136,7 +191,7 @@ export function useFruitMarketGame() {
   };
 
   const submitBids = () => {
-    if (!currentPlayer) return;
+    if (!currentPlayer || !bidComplete) return;
     let nextPlayers = players;
     let nextSecretFruits = secretFruits;
 
@@ -247,9 +302,11 @@ export function useFruitMarketGame() {
     participants,
     requiredCount,
     totalCount,
+    maxFruitCount,
     marketFruits,
     currentPlayer,
     currentPlayerFruits,
+    replacementFruitOptions,
     bidFruits,
     setupReady,
     bidComplete,
@@ -260,6 +317,8 @@ export function useFruitMarketGame() {
     selectSpecial,
     setPlayerBid,
     submitBids,
+    closePrivateRoom,
+    leaveDealerRoomWithoutSubmitting,
     nextRound,
   };
 }

--- a/home/src/features/fruit-market/hooks/useFruitMarketGame.ts
+++ b/home/src/features/fruit-market/hooks/useFruitMarketGame.ts
@@ -4,6 +4,7 @@ import {
   FruitMarketBids,
   FruitMarketPhase,
   FruitMarketPlayer,
+  FruitMarketRoundLog,
   FruitMarketRoundResult,
   FruitMarketSpecial,
 } from "@/features/fruit-market/types";
@@ -66,6 +67,10 @@ export function useFruitMarketGame() {
   const [bids, setBids] = useState<FruitMarketBids>({});
   const [secretFruits, setSecretFruits] = useState<Fruit[]>([]);
   const [results, setResults] = useState<FruitMarketRoundResult[]>([]);
+  const [gameLogs, setGameLogs] = useState<FruitMarketRoundLog[]>([]);
+  const [currentRoundLogs, setCurrentRoundLogs] = useState<
+    FruitMarketRoundLog["players"]
+  >([]);
   const [special, setSpecial] = useState<FruitMarketSpecial>("none");
   const [targetFruit, setTargetFruit] = useState<Fruit>("사과");
   const [replacementFruit, setReplacementFruit] = useState<Fruit>("딸기");
@@ -194,8 +199,26 @@ export function useFruitMarketGame() {
     if (!currentPlayer || !bidComplete) return;
     let nextPlayers = players;
     let nextSecretFruits = secretFruits;
+    const currentPlayerBids = { ...(bids[currentPlayer.id] ?? {}) };
+    const nextBids = {
+      ...bids,
+      [currentPlayer.id]: currentPlayerBids,
+    };
+    const submittedSpecial = special;
+    const submittedTargetFruit = special !== "none" ? targetFruit : undefined;
+    const submittedReplacementFruit =
+      special === "replace" ? replacementFruit : undefined;
+    const submittedLog = {
+      playerId: currentPlayer.id,
+      playerName: currentPlayer.name,
+      bids: currentPlayerBids,
+      special: submittedSpecial,
+      targetFruit: submittedTargetFruit,
+      replacementFruit: submittedReplacementFruit,
+    };
+    const nextCurrentRoundLogs = [...currentRoundLogs, submittedLog];
 
-    if (special === "secret") {
+    if (submittedSpecial === "secret") {
       nextSecretFruits = [...secretFruits, targetFruit];
       nextPlayers = players.map((player) =>
         player.id === currentPlayer.id
@@ -204,7 +227,7 @@ export function useFruitMarketGame() {
       );
     }
 
-    if (special === "replace") {
+    if (submittedSpecial === "replace") {
       nextPlayers = players.map((player) => {
         if (player.id !== currentPlayer.id) return player;
         const fruits = [...player.fruits];
@@ -223,12 +246,17 @@ export function useFruitMarketGame() {
     const nextBidPlayerIds = [...bidPlayerIds, currentPlayer.id];
     setBidPlayerIds(nextBidPlayerIds);
     if (nextBidPlayerIds.length < players.length) {
+      setCurrentRoundLogs(nextCurrentRoundLogs);
       closePrivateRoom();
       return;
     }
 
     const incomeByPlayer: Record<number, number> = {};
     const roundResults: FruitMarketRoundResult[] = [];
+    const roundLog: FruitMarketRoundLog = {
+      round,
+      players: nextCurrentRoundLogs,
+    };
     const sellingFruits = uniqueFruits(
       nextPlayers.flatMap((player) => player.fruits),
     );
@@ -238,10 +266,10 @@ export function useFruitMarketGame() {
         player.fruits.includes(fruit),
       );
       const price = Math.min(
-        ...sellers.map((player) => bids[player.id]?.[fruit] as number),
+        ...sellers.map((player) => nextBids[player.id]?.[fruit] as number),
       );
       const winners = sellers.filter(
-        (player) => bids[player.id]?.[fruit] === price,
+        (player) => nextBids[player.id]?.[fruit] === price,
       );
       const revenue = price * sellers.length;
       const share = Math.floor(revenue / winners.length);
@@ -262,6 +290,8 @@ export function useFruitMarketGame() {
         income: player.income + (incomeByPlayer[player.id] ?? 0),
       })),
     );
+    setGameLogs((previous) => [...previous, roundLog]);
+    setCurrentRoundLogs([]);
     setResults(roundResults);
     setPhase("result");
     closePrivateRoom();
@@ -278,6 +308,7 @@ export function useFruitMarketGame() {
     setBids({});
     setSecretFruits([]);
     setReplacementNotices([]);
+    setCurrentRoundLogs([]);
     setPhase("bid");
   };
 
@@ -293,6 +324,7 @@ export function useFruitMarketGame() {
     setRoomOpen,
     bids,
     results,
+    gameLogs,
     special,
     targetFruit,
     setTargetFruit,

--- a/home/src/features/fruit-market/types.ts
+++ b/home/src/features/fruit-market/types.ts
@@ -22,3 +22,17 @@ export interface FruitMarketRoundResult {
   revenue: number;
   hidden: boolean;
 }
+
+export interface FruitMarketPlayerRoundLog {
+  playerId: number;
+  playerName: string;
+  bids: Partial<Record<Fruit, number>>;
+  special: FruitMarketSpecial;
+  targetFruit?: Fruit;
+  replacementFruit?: Fruit;
+}
+
+export interface FruitMarketRoundLog {
+  round: number;
+  players: FruitMarketPlayerRoundLog[];
+}


### PR DESCRIPTION
## Summary
- prevent assigning duplicate fruit types to a single player during initial distribution
- prevent fruit replacement into a fruit the player already owns
- add a no-submit back action from the dealer room
- add a final game log modal showing each round's bids and special actions

## Verification
- npm run build *(fails because react-qr-code is missing from the local node_modules and SuspectVoteModal.tsx cannot resolve it)*